### PR TITLE
Fix user not found while adding indexer

### DIFF
--- a/app/api/indexers/route.ts
+++ b/app/api/indexers/route.ts
@@ -75,10 +75,19 @@ export async function POST(request: Request)
                         });
 
                         userId = user.id;
+                    } else {
+                        return NextResponse.json({
+                            success: false,
+                            message: 'User not found'
+                        }, { status: 404 });
                     }
                 }
             } catch (authError) {
                 console.error('Authentication error:', authError);
+                return NextResponse.json({
+                    success: false,
+                    message: 'User not found'
+                }, { status: 404 });
             }
         }
 
@@ -155,15 +164,10 @@ export async function POST(request: Request)
                 }, { status: 500 });
             }
         } else {
-            // Create indexer without user association
-            // const indexer = await prisma.indexer.create({
-            //     data: indexerData
-            // });
-
             return NextResponse.json({
                 success: false,
                 message: 'User not found'
-            }, { status: 201 });
+            }, { status: 404 });
         }
 
     } catch (error) {
@@ -203,8 +207,8 @@ export async function GET(request: Request)
             const privyUser = await privy.getUser(verifiedClaims.userId);
             if (!privyUser || !privyUser.wallet) {
                 return NextResponse.json({
-                    error: "No wallet associated with user"
-                }, { status: 400 });
+                    error: "User not found"
+                }, { status: 404 });
             }
 
             walletAddress = privyUser.wallet.address;

--- a/app/components/dashboard.tsx
+++ b/app/components/dashboard.tsx
@@ -28,7 +28,7 @@ interface Indexer
 
 export default function Dashboard()
 {
-    const { user } = usePrivy();
+    const { user, getAccessToken } = usePrivy();
     const [showAddIndexerModal, setShowAddIndexerModal] = useState(false);
     const [indexerName, setIndexerName] = useState('');
     const [postgresUrl, setPostgresUrl] = useState('');
@@ -47,6 +47,8 @@ export default function Dashboard()
             setError('');
 
             try {
+                const authToken = await getAccessToken();
+
                 const response = await fetch('/api/indexers', {
                     method: 'POST',
                     headers: {
@@ -57,7 +59,8 @@ export default function Dashboard()
                         postgresUrl: postgresUrl,
                         solanaAddress: solanaAddress,
                         eventTypes: eventTypes,
-                        filter: indexerFilter
+                        filter: indexerFilter,
+                        authToken: authToken
                     }),
                 });
 


### PR DESCRIPTION
Fix user not found issue while adding indexer.

* Modify `app/api/indexers/route.ts` to return a specific error message "User not found" with a 404 status if the user is not found in the `POST` function.
* Create an indexer without user association if the user is not found, returning a "User not found" message with a 404 status in the `POST` function.
* Fetch the user using the wallet address from Privy and return a "User not found" message with a 404 status if the user is not found in the `GET` function.
* Modify `app/components/dashboard.tsx` to obtain the `authToken` using `getAccessToken()` from the `usePrivy` hook and send it to the backend when adding an indexer.

